### PR TITLE
Use Temurin (OpenJDK) instead of Zulu

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,7 +29,7 @@ jobs:
       matrix:
         os: [ubuntu-latest]
         scala: [2.12, 2.13, 3]
-        java: [zulu@8]
+        java: [temurin@8]
     runs-on: ${{ matrix.os }}
     timeout-minutes: 60
     steps:
@@ -38,17 +38,26 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Setup Java (zulu@8)
-        id: setup-java-zulu-8
-        if: matrix.java == 'zulu@8'
+      - name: Download Java (temurin@8)
+        id: download-java-temurin-8
+        if: matrix.java == 'temurin@8'
+        uses: typelevel/download-java@v2
+        with:
+          distribution: temurin
+          java-version: 8
+
+      - name: Setup Java (temurin@8)
+        id: setup-java-temurin-8
+        if: matrix.java == 'temurin@8'
         uses: actions/setup-java@v3
         with:
-          distribution: zulu
+          distribution: jdkfile
           java-version: 8
+          jdkFile: ${{ steps.download-java-temurin-8.outputs.jdkFile }}
           cache: sbt
 
       - name: sbt update
-        if: matrix.java == 'zulu@8' && steps.setup-java-zulu-8.outputs.cache-hit == 'false'
+        if: matrix.java == 'temurin@8' && steps.setup-java-temurin-8.outputs.cache-hit == 'false'
         run: sbt '++ ${{ matrix.scala }}' reload +update
 
       - name: Check that workflows are up to date
@@ -80,7 +89,7 @@ jobs:
       matrix:
         os: [ubuntu-latest]
         scala: [2.13.10]
-        java: [zulu@8]
+        java: [temurin@8]
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout current branch (full)
@@ -88,17 +97,26 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Setup Java (zulu@8)
-        id: setup-java-zulu-8
-        if: matrix.java == 'zulu@8'
+      - name: Download Java (temurin@8)
+        id: download-java-temurin-8
+        if: matrix.java == 'temurin@8'
+        uses: typelevel/download-java@v2
+        with:
+          distribution: temurin
+          java-version: 8
+
+      - name: Setup Java (temurin@8)
+        id: setup-java-temurin-8
+        if: matrix.java == 'temurin@8'
         uses: actions/setup-java@v3
         with:
-          distribution: zulu
+          distribution: jdkfile
           java-version: 8
+          jdkFile: ${{ steps.download-java-temurin-8.outputs.jdkFile }}
           cache: sbt
 
       - name: sbt update
-        if: matrix.java == 'zulu@8' && steps.setup-java-zulu-8.outputs.cache-hit == 'false'
+        if: matrix.java == 'temurin@8' && steps.setup-java-temurin-8.outputs.cache-hit == 'false'
         run: sbt '++ ${{ matrix.scala }}' reload +update
 
       - name: Download target directories (2.12)

--- a/build.sbt
+++ b/build.sbt
@@ -1,10 +1,10 @@
-import org.typelevel.sbt.gha.JavaSpec.Distribution.Zulu
+import org.typelevel.sbt.gha.JavaSpec.Distribution.Temurin
 
 ThisBuild / organization := "com.github.pjfanning"
 ThisBuild / crossScalaVersions := List("2.12.17", "2.13.10", "3.3.0")
 ThisBuild / scalaVersion := "2.13.10"
 
-ThisBuild / githubWorkflowJavaVersions := Seq(JavaSpec(Zulu, "8"))
+ThisBuild / githubWorkflowJavaVersions := Seq(JavaSpec(Temurin, "8"))
 ThisBuild / githubWorkflowPublishTargetBranches := Seq(
   RefPredicate.Equals(Ref.Branch("main")),
   RefPredicate.StartsWith(Ref.Tag("v"))


### PR DESCRIPTION
While Zulu is probably fine, its preferable to use OpenJDK build such as Temurin especially for publishing (and this library is being used by Pekko). @pjfanning 