### PR TITLE
Remove scala-java8-compat dependency

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -74,7 +74,6 @@ lazy val deps = {
     "org.apache.pekko"        %% "pekko-stream"            % pekkoVersion,
     "org.apache.pekko"        %% "pekko-http"              % pekkoHttpVersion,
     "software.amazon.awssdk"  %  "http-client-spi"         % awsSDKVersion,
-    "org.scala-lang.modules"  %% "scala-java8-compat"      % "1.0.2",
     "org.scala-lang.modules"  %% "scala-collection-compat" % "2.7.0",
 
     "software.amazon.awssdk"  %  "s3"                      % awsSDKVersion   % "test" exclude("software.amazon.awssdk", "netty-nio-client"),

--- a/src/main/scala-2.12/com/github/pjfanning/pekkohttpspi/FutureConverters.scala
+++ b/src/main/scala-2.12/com/github/pjfanning/pekkohttpspi/FutureConverters.scala
@@ -1,0 +1,9 @@
+package com.github.pjfanning.pekkohttpspi
+
+import java.util.concurrent.CompletionStage
+import scala.concurrent.Future
+
+private[pekkohttpspi] object FutureConverters {
+  @inline final def asJava[T](f: Future[T]): CompletionStage[T] = scala.compat.java8.FutureConverters.toJava(f)
+
+}

--- a/src/main/scala-2.12/com/github/pjfanning/pekkohttpspi/OptionConverters.scala
+++ b/src/main/scala-2.12/com/github/pjfanning/pekkohttpspi/OptionConverters.scala
@@ -1,0 +1,7 @@
+package com.github.pjfanning.pekkohttpspi
+
+import java.util.Optional
+
+private[pekkohttpspi] object OptionConverters {
+  @inline final def toScala[A](o: Optional[A]): Option[A] = scala.compat.java8.OptionConverters.toScala(o)
+}

--- a/src/main/scala-2.13/com/github/pjfanning/pekkohttpspi/FutureConverters.scala
+++ b/src/main/scala-2.13/com/github/pjfanning/pekkohttpspi/FutureConverters.scala
@@ -1,0 +1,9 @@
+package com.github.pjfanning.pekkohttpspi
+
+import java.util.concurrent.CompletionStage
+import scala.concurrent.Future
+import scala.jdk.javaapi
+
+private[pekkohttpspi] object FutureConverters {
+  @inline final def asJava[T](f: Future[T]): CompletionStage[T] = javaapi.FutureConverters.asJava(f)
+}

--- a/src/main/scala-2.13/com/github/pjfanning/pekkohttpspi/OptionConverters.scala
+++ b/src/main/scala-2.13/com/github/pjfanning/pekkohttpspi/OptionConverters.scala
@@ -1,0 +1,8 @@
+package com.github.pjfanning.pekkohttpspi
+
+import java.util.Optional
+
+private[pekkohttpspi] object OptionConverters {
+  @inline final def toScala[A](o: Optional[A]): Option[A] = scala.jdk.javaapi.OptionConverters.toScala(o)
+}
+

--- a/src/main/scala-3/com/github/pjfanning/pekkohttpspi/FutureConverters.scala
+++ b/src/main/scala-3/com/github/pjfanning/pekkohttpspi/FutureConverters.scala
@@ -1,0 +1,9 @@
+package com.github.pjfanning.pekkohttpspi
+
+import java.util.concurrent.CompletionStage
+import scala.concurrent.Future
+import scala.jdk.javaapi
+
+private[pekkohttpspi] object FutureConverters {
+  inline final def asJava[T](f: Future[T]): CompletionStage[T] = javaapi.FutureConverters.asJava(f)
+}

--- a/src/main/scala-3/com/github/pjfanning/pekkohttpspi/OptionConverters.scala
+++ b/src/main/scala-3/com/github/pjfanning/pekkohttpspi/OptionConverters.scala
@@ -1,0 +1,7 @@
+package com.github.pjfanning.pekkohttpspi
+
+import java.util.Optional
+
+object OptionConverters {
+  final inline def toScala[A](o: Optional[A]): Option[A] = scala.jdk.javaapi.OptionConverters.toScala(o)
+}

--- a/src/main/scala/com/github/pjfanning/pekkohttpspi/PekkoHttpClient.scala
+++ b/src/main/scala/com/github/pjfanning/pekkohttpspi/PekkoHttpClient.scala
@@ -37,7 +37,6 @@ import software.amazon.awssdk.utils.AttributeMap
 
 import scala.collection.immutable
 import scala.jdk.CollectionConverters._
-import scala.compat.java8.OptionConverters._
 import scala.concurrent.duration.Duration
 import scala.concurrent.{Await, ExecutionContext}
 
@@ -81,7 +80,7 @@ object PekkoHttpClient {
                                                          contentType: ContentType,
                                                          contentPublisher: SdkHttpContentPublisher): RequestEntity =
     method.requestEntityAcceptance match {
-      case Expected => contentPublisher.contentLength().asScala match {
+      case Expected => OptionConverters.toScala(contentPublisher.contentLength()) match {
         case Some(length) => HttpEntity(contentType, length, Source.fromPublisher(contentPublisher).map(ByteString(_)))
         case None         => HttpEntity(contentType, Source.fromPublisher(contentPublisher).map(ByteString(_)))
       }

--- a/src/main/scala/com/github/pjfanning/pekkohttpspi/RequestRunner.scala
+++ b/src/main/scala/com/github/pjfanning/pekkohttpspi/RequestRunner.scala
@@ -27,7 +27,6 @@ import org.slf4j.LoggerFactory
 import software.amazon.awssdk.http.SdkHttpFullResponse
 import software.amazon.awssdk.http.async.SdkAsyncHttpResponseHandler
 
-import scala.compat.java8.FutureConverters
 import scala.concurrent.{ExecutionContext, Future}
 import scala.jdk.CollectionConverters._
 
@@ -53,7 +52,7 @@ class RequestRunner()(implicit sys: ActorSystem, ec: ExecutionContext, mat: Mate
     }
 
     result.failed.foreach(handler.onError)
-    FutureConverters.toJava(result.map(_ => null: Void)).toCompletableFuture
+    FutureConverters.asJava(result.map(_ => null: Void)).toCompletableFuture
   }
 
   private[pekkohttpspi] def toSdkHttpFullResponse(response: HttpResponse): SdkHttpFullResponse = {

--- a/src/test/scala/com/github/pjfanning/pekkohttpspi/testcontainers/LocalStackReadyLogWaitStrategy.scala
+++ b/src/test/scala/com/github/pjfanning/pekkohttpspi/testcontainers/LocalStackReadyLogWaitStrategy.scala
@@ -25,7 +25,6 @@ import org.testcontainers.containers.output.{OutputFrame, WaitingConsumer}
 import org.testcontainers.containers.wait.strategy.AbstractWaitStrategy
 import org.testcontainers.utility.LogUtils
 
-import scala.compat.java8.FunctionConverters._
 /**
   * This strategy is based on the container log "Ready." from Localstack.
   * Once it's printed out, the container is good to go.
@@ -35,7 +34,7 @@ object LocalStackReadyLogWaitStrategy extends AbstractWaitStrategy {
     val waitingConsumer = new WaitingConsumer
     LogUtils.followOutput(DockerClientFactory.instance.client, waitStrategyTarget.getContainerId, waitingConsumer)
 
-    val waitPredicate: Predicate[OutputFrame] = ((outputFrame: OutputFrame) => outputFrame.getUtf8String.contains("Ready.")).asJava
+    val waitPredicate: Predicate[OutputFrame] = (outputFrame: OutputFrame) => outputFrame.getUtf8String.contains("Ready.")
 
     try
       waitingConsumer.waitUntil(waitPredicate, startupTimeout.getSeconds, TimeUnit.SECONDS, 1)


### PR DESCRIPTION
Same reasoning behind https://github.com/lomigmegard/pekko-http-cors/pull/19. Also this PR requires https://github.com/pjfanning/aws-spi-pekko-http/pull/3 to be merged for the inline to do anything. @pjfanning 