### PR TITLE
Remove scala-collection-compat

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -81,7 +81,6 @@ lazy val deps = {
     "org.apache.pekko"        %% "pekko-stream"            % pekkoVersion,
     "org.apache.pekko"        %% "pekko-http"              % pekkoHttpVersion,
     "software.amazon.awssdk"  %  "http-client-spi"         % awsSDKVersion,
-    "org.scala-lang.modules"  %% "scala-collection-compat" % "2.7.0",
 
     "software.amazon.awssdk"  %  "s3"                      % awsSDKVersion   % "test" exclude("software.amazon.awssdk", "netty-nio-client"),
     "software.amazon.awssdk"  %  "dynamodb"                % awsSDKVersion   % "test" exclude("software.amazon.awssdk", "netty-nio-client"),

--- a/src/test/scala/com/github/pjfanning/pekkohttpspi/PekkoHttpClientSpec.scala
+++ b/src/test/scala/com/github/pjfanning/pekkohttpspi/PekkoHttpClientSpec.scala
@@ -16,13 +16,13 @@
 
 package com.github.pjfanning.pekkohttpspi
 
+import java.util.Collections
+
 import org.apache.pekko.http.scaladsl.model.headers.`Content-Type`
 import org.apache.pekko.http.scaladsl.model.MediaTypes
 import org.scalatest.OptionValues
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
-
-import scala.jdk.CollectionConverters._
 
 class PekkoHttpClientSpec extends AnyWordSpec with Matchers with OptionValues {
 
@@ -35,11 +35,10 @@ class PekkoHttpClientSpec extends AnyWordSpec with Matchers with OptionValues {
     }
 
     "remove 'ContentType' return 'ContentLength' separate from sdk headers" in {
-      val headers = collection.immutable.Map(
-        "Content-Type" -> List("application/xml").asJava,
-        "Content-Length"-> List("123").asJava,
-        "Accept" -> List("*/*").asJava
-      ).asJava
+      val headers = new java.util.HashMap[String, java.util.List[String]]
+      headers.put("Content-Type", Collections.singletonList("application/xml"))
+      headers.put("Content-Length", Collections.singletonList("123"))
+      headers.put("Accept", Collections.singletonList("*/*"))
 
       val (contentTypeHeader, reqHeaders) = PekkoHttpClient.convertHeaders(headers)
 

--- a/src/test/scala/com/github/pjfanning/pekkohttpspi/RequestRunnerSpec.scala
+++ b/src/test/scala/com/github/pjfanning/pekkohttpspi/RequestRunnerSpec.scala
@@ -30,7 +30,6 @@ import software.amazon.awssdk.http.SdkHttpResponse
 import software.amazon.awssdk.http.async.SdkAsyncHttpResponseHandler
 
 import scala.concurrent.Future
-import scala.jdk.CollectionConverters._
 
 class RequestRunnerSpec extends AnyWordSpec with Matchers with OptionValues {
   "Check headers are present from response" in {
@@ -42,9 +41,9 @@ class RequestRunnerSpec extends AnyWordSpec with Matchers with OptionValues {
     val resp = runner.run(() => Future.successful(response), handler)
     resp.join()
 
-    handler.responseHeaders.headers().asScala.get("User-Agent").value.asScala.headOption.value shouldBe "Mozilla"
-    handler.responseHeaders.headers().asScala.get("Content-Type").value.asScala.headOption.value shouldBe "text/plain; charset=UTF-8"
-    handler.responseHeaders.headers().asScala.get("Content-Length").value.asScala.headOption.value shouldBe "2"
+    handler.responseHeaders.headers().get("User-Agent").get(0) shouldBe "Mozilla"
+    handler.responseHeaders.headers().get("Content-Type").get(0) shouldBe "text/plain; charset=UTF-8"
+    handler.responseHeaders.headers().get("Content-Length").get(0) shouldBe "2"
   }
 
   class MyHeaderHandler() extends SdkAsyncHttpResponseHandler {

--- a/src/test/scala/com/github/pjfanning/pekkohttpspi/dynamodb/TestDynamoDB.scala
+++ b/src/test/scala/com/github/pjfanning/pekkohttpspi/dynamodb/TestDynamoDB.scala
@@ -21,8 +21,6 @@ import software.amazon.awssdk.auth.credentials.{AwsBasicCredentials, StaticCrede
 import software.amazon.awssdk.services.dynamodb.DynamoDbAsyncClient
 import software.amazon.awssdk.services.dynamodb.model._
 
-import scala.jdk.CollectionConverters._
-
 class TestDynamoDB extends LocalstackBaseAwsClientTest[DynamoDbAsyncClient] {
   "DynamoDB" should {
     "create a table" in withClient { implicit client =>
@@ -30,7 +28,7 @@ class TestDynamoDB extends LocalstackBaseAwsClientTest[DynamoDbAsyncClient] {
       val keySchema = KeySchemaElement.builder.attributeName("film_id").keyType(KeyType.HASH).build()
 
       val emptyTableResult = client.listTables().join()
-      emptyTableResult.tableNames().asScala should have size (0)
+      emptyTableResult.tableNames() should have size (0)
 
       val result = client.createTable(
         CreateTableRequest.builder()
@@ -44,7 +42,7 @@ class TestDynamoDB extends LocalstackBaseAwsClientTest[DynamoDbAsyncClient] {
       desc.tableName() should be("Movies")
 
       val tableResult = client.listTables().join()
-      tableResult.tableNames().asScala should have size (1)
+      tableResult.tableNames() should have size (1)
     }
 
   }

--- a/src/test/scala/com/github/pjfanning/pekkohttpspi/s3/TestS3.scala
+++ b/src/test/scala/com/github/pjfanning/pekkohttpspi/s3/TestS3.scala
@@ -25,7 +25,6 @@ import software.amazon.awssdk.core.async.{AsyncRequestBody, AsyncResponseTransfo
 import software.amazon.awssdk.services.s3.{S3AsyncClient, S3Configuration}
 import software.amazon.awssdk.services.s3.model._
 
-import scala.jdk.CollectionConverters._
 import scala.concurrent.duration._
 import scala.language.postfixOps
 import scala.util.Random
@@ -37,7 +36,7 @@ class TestS3 extends BaseAwsClientTest[S3AsyncClient] {
       val bucketName = createBucket()
       val buckets = client.listBuckets().join
       buckets.buckets() should have size (1)
-      buckets.buckets().asScala.toList.head.name() should be(bucketName)
+      buckets.buckets().get(0).name() should be(bucketName)
     }
 
     "upload and download a file to a bucket" in withClient { implicit client =>


### PR DESCRIPTION
So unfortunately this PR was a bit more involved as it involved converting usage of Scala collections to Java and vice versa. Arguably in a lot of cases the code is clearer/faster (there was a lot of unnecessary converting from Scala collections to Java collections, often multiple times in one go even though you could have just created a Java collection initially) but there are some cases where more boilerplate was added, specifically when we needed to convert from a Java collection to Scala and using a builder.

Note that this will be important when dropping Scala 2.12 down the line, the `scala-collection-compat` is only relevant for cross compiling Scala 2.13+ collection code to Scala 2.12 and just like the removal of `scala-java8-compat`, this allows us to drop Scala 2.12 without breaking anything.