### PR TITLE
Rename references of Akka to Pekko

### DIFF
--- a/.scala-steward.conf
+++ b/.scala-steward.conf
@@ -2,5 +2,5 @@
 # Each pattern must have `groupId`, and may have `artifactId` and `version`.
 # Defaults to empty `[]` which mean Scala Steward will not ignore dependencies.
 updates.ignore = [ { groupId = "software.amazon.awssdk" },
-                   { groupId = "com.typesafe.akka", artifactId = "akka-stream" }
+                   { groupId = "org.apache.pekko", artifactId = "pekko-stream" }
                  ]

--- a/src/it/resources/application.conf
+++ b/src/it/resources/application.conf
@@ -1,1 +1,1 @@
-akka.http.client.parsing.max-content-length = 15m
+pekko.http.client.parsing.max-content-length = 15m

--- a/src/test/resources/logback-test.xml
+++ b/src/test/resources/logback-test.xml
@@ -21,11 +21,11 @@
     <logger name="com.typesafe" level="error" additivity="false">
         <appender-ref ref="STDOUT" />
     </logger>
-    <logger name="akka.http" level="error" additivity="false">
+    <logger name="org.apache.pekko.http" level="error" additivity="false">
         <appender-ref ref="STDOUT" />
     </logger>
-    <!-- Log of http content // with akka.http.client.log-unencrypted-network-bytes = 10000 -->
-    <logger name="akka.stream" level="error" additivity="false">
+    <!-- Log of http content // with pekko.http.client.log-unencrypted-network-bytes = 10000 -->
+    <logger name="org.apache.pekko.stream" level="error" additivity="false">
         <appender-ref ref="STDOUT" />
     </logger>
     <logger name="org.testcontainers" level="info" additivity="false">


### PR DESCRIPTION
Not critical right now but good to get this in before an actual release @pjfanning 