### PR TITLE
Fix it tests not compiling due to FutureConverters

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,7 +55,7 @@ jobs:
         run: sbt githubWorkflowCheck
 
       - name: Build project
-        run: sbt '++ ${{ matrix.scala }}' test
+        run: 'sbt ''++ ${{ matrix.scala }}'' it:compile test'
 
       - name: Make target directories
         if: github.event_name != 'pull_request' && (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/v'))

--- a/build.sbt
+++ b/build.sbt
@@ -22,6 +22,8 @@ ThisBuild / githubWorkflowPublish := Seq(
   )
 )
 
+ThisBuild / githubWorkflowBuild := Seq(WorkflowStep.Sbt(List("it:compile", "test"), name = Some("Build project")))
+
 ThisBuild / mimaPreviousArtifacts := Set.empty
 ThisBuild / resolvers += "Apache Nexus Snapshots".at("https://repository.apache.org/content/repositories/snapshots/")
 

--- a/src/it/scala/com/github/pjfanning/pekkohttpspi/dynamodb/ITTestDynamoDB.scala
+++ b/src/it/scala/com/github/pjfanning/pekkohttpspi/dynamodb/ITTestDynamoDB.scala
@@ -16,15 +16,13 @@
 
 package com.github.pjfanning.pekkohttpspi.dynamodb
 
-import com.github.pjfanning.pekkohttpspi.{PekkoHttpAsyncHttpService, TestBase}
+import com.github.pjfanning.pekkohttpspi.{FutureConverters, PekkoHttpAsyncHttpService, TestBase}
 import org.scalatest.concurrent.{Eventually, Futures, IntegrationPatience}
 import org.scalatest.wordspec.AnyWordSpec
 import org.scalatest.matchers.should.Matchers
 import software.amazon.awssdk.services.dynamodb.DynamoDbAsyncClient
 import software.amazon.awssdk.services.dynamodb.model._
 import org.scalatest.concurrent.ScalaFutures._
-
-import scala.compat.java8.FutureConverters._
 
 class ITTestDynamoDB
     extends AnyWordSpec
@@ -80,10 +78,11 @@ class ITTestDynamoDB
       desc.tableName() should be(tableName)
 
       eventually {
-        val response = client.describeTable(DescribeTableRequest.builder().tableName(tableName).build()).toScala
+        val response =
+          FutureConverters.asScala(client.describeTable(DescribeTableRequest.builder().tableName(tableName).build()))
         response.futureValue.table().tableStatus() should be(TableStatus.ACTIVE)
       }
-      client.deleteTable(DeleteTableRequest.builder().tableName(tableName).build()).toScala
+      FutureConverters.asScala(client.deleteTable(DeleteTableRequest.builder().tableName(tableName).build()))
 
     }
   }

--- a/src/main/scala-2.12/com/github/pjfanning/pekkohttpspi/FutureConverters.scala
+++ b/src/main/scala-2.12/com/github/pjfanning/pekkohttpspi/FutureConverters.scala
@@ -6,4 +6,6 @@ import scala.concurrent.Future
 private[pekkohttpspi] object FutureConverters {
   @inline final def asJava[T](f: Future[T]): CompletionStage[T] = scala.compat.java8.FutureConverters.toJava(f)
 
+  @inline final def asScala[T](cs: CompletionStage[T]): Future[T] = scala.compat.java8.FutureConverters.toScala(cs)
+
 }

--- a/src/main/scala-2.13/com/github/pjfanning/pekkohttpspi/FutureConverters.scala
+++ b/src/main/scala-2.13/com/github/pjfanning/pekkohttpspi/FutureConverters.scala
@@ -6,4 +6,6 @@ import scala.jdk.javaapi
 
 private[pekkohttpspi] object FutureConverters {
   @inline final def asJava[T](f: Future[T]): CompletionStage[T] = javaapi.FutureConverters.asJava(f)
+
+  @inline final def asScala[T](cs: CompletionStage[T]): Future[T] = javaapi.FutureConverters.asScala(cs)
 }

--- a/src/main/scala-3/com/github/pjfanning/pekkohttpspi/FutureConverters.scala
+++ b/src/main/scala-3/com/github/pjfanning/pekkohttpspi/FutureConverters.scala
@@ -6,4 +6,6 @@ import scala.jdk.javaapi
 
 private[pekkohttpspi] object FutureConverters {
   inline final def asJava[T](f: Future[T]): CompletionStage[T] = javaapi.FutureConverters.asJava(f)
+
+  inline final def asScala[T](cs: CompletionStage[T]): Future[T] = javaapi.FutureConverters.asScala(cs)
 }


### PR DESCRIPTION
It appears that this project has integration tests (technically `it` scope within sbt terminology) which doesn't compile with the standard `compile` command. This means that when doing https://github.com/pjfanning/aws-spi-pekko-http/pull/1 I managed to miss converting some functions due to both me locally not running `it:compile` and the github actions CI not doing it.

This PR rectifies all of these issues.