### PR TITLE
Use org.apache.pekko as root import

### DIFF
--- a/src/main/scala/com/github/pjfanning/pekkohttpspi/PekkoHttpClient.scala
+++ b/src/main/scala/com/github/pjfanning/pekkohttpspi/PekkoHttpClient.scala
@@ -18,18 +18,19 @@ package com.github.pjfanning.pekkohttpspi
 
 import java.util.concurrent.{CompletableFuture, TimeUnit}
 
-import org.apache.pekko.actor.{ActorSystem, ClassicActorSystemProvider}
-import org.apache.pekko.http.scaladsl.Http
-import org.apache.pekko.http.scaladsl.model.HttpHeader.ParsingResult
-import org.apache.pekko.http.scaladsl.model.HttpHeader.ParsingResult.Ok
-import org.apache.pekko.http.scaladsl.model.MediaType.Compressible
-import org.apache.pekko.http.scaladsl.model.RequestEntityAcceptance.Expected
-import org.apache.pekko.http.scaladsl.model._
-import org.apache.pekko.http.scaladsl.model.headers.{`Content-Length`, `Content-Type`}
-import org.apache.pekko.http.scaladsl.settings.ConnectionPoolSettings
-import org.apache.pekko.stream.scaladsl.Source
-import org.apache.pekko.stream.{ActorMaterializer, Materializer, SystemMaterializer}
-import org.apache.pekko.util.ByteString
+import org.apache.pekko
+import pekko.actor.{ActorSystem, ClassicActorSystemProvider}
+import pekko.http.scaladsl.Http
+import pekko.http.scaladsl.model.HttpHeader.ParsingResult
+import pekko.http.scaladsl.model.HttpHeader.ParsingResult.Ok
+import pekko.http.scaladsl.model.MediaType.Compressible
+import pekko.http.scaladsl.model.RequestEntityAcceptance.Expected
+import pekko.http.scaladsl.model._
+import pekko.http.scaladsl.model.headers.{`Content-Length`, `Content-Type`}
+import pekko.http.scaladsl.settings.ConnectionPoolSettings
+import pekko.stream.scaladsl.Source
+import pekko.stream.{ActorMaterializer, Materializer, SystemMaterializer}
+import pekko.util.ByteString
 import org.slf4j.LoggerFactory
 import software.amazon.awssdk.http.async._
 import software.amazon.awssdk.http.SdkHttpRequest

--- a/src/main/scala/com/github/pjfanning/pekkohttpspi/RequestRunner.scala
+++ b/src/main/scala/com/github/pjfanning/pekkohttpspi/RequestRunner.scala
@@ -19,11 +19,12 @@ package com.github.pjfanning.pekkohttpspi
 import java.util.concurrent.CompletableFuture
 import java.util.Collections
 
-import org.apache.pekko.actor.ActorSystem
-import org.apache.pekko.http.scaladsl.model.{ContentTypes, HttpResponse}
-import org.apache.pekko.http.scaladsl.model.headers.{`Content-Length`, `Content-Type`}
-import org.apache.pekko.stream.Materializer
-import org.apache.pekko.stream.scaladsl.{Keep, Sink}
+import org.apache.pekko
+import pekko.actor.ActorSystem
+import pekko.http.scaladsl.model.{ContentTypes, HttpResponse}
+import pekko.http.scaladsl.model.headers.{`Content-Length`, `Content-Type`}
+import pekko.stream.Materializer
+import pekko.stream.scaladsl.{Keep, Sink}
 import org.slf4j.LoggerFactory
 import software.amazon.awssdk.http.SdkHttpFullResponse
 import software.amazon.awssdk.http.async.SdkAsyncHttpResponseHandler

--- a/src/test/scala/com/github/pjfanning/pekkohttpspi/PekkoHttpClientSpec.scala
+++ b/src/test/scala/com/github/pjfanning/pekkohttpspi/PekkoHttpClientSpec.scala
@@ -18,8 +18,9 @@ package com.github.pjfanning.pekkohttpspi
 
 import java.util.Collections
 
-import org.apache.pekko.http.scaladsl.model.headers.`Content-Type`
-import org.apache.pekko.http.scaladsl.model.MediaTypes
+import org.apache.pekko
+import pekko.http.scaladsl.model.headers.`Content-Type`
+import pekko.http.scaladsl.model.MediaTypes
 import org.scalatest.OptionValues
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec

--- a/src/test/scala/com/github/pjfanning/pekkohttpspi/RequestRunnerSpec.scala
+++ b/src/test/scala/com/github/pjfanning/pekkohttpspi/RequestRunnerSpec.scala
@@ -19,9 +19,10 @@ package com.github.pjfanning.pekkohttpspi
 import java.nio.ByteBuffer
 import java.util.concurrent.atomic.AtomicReference
 
-import org.apache.pekko.actor.ActorSystem
-import org.apache.pekko.http.scaladsl.model.headers.`User-Agent`
-import org.apache.pekko.http.scaladsl.model.{HttpEntity, HttpResponse}
+import org.apache.pekko
+import pekko.actor.ActorSystem
+import pekko.http.scaladsl.model.headers.`User-Agent`
+import pekko.http.scaladsl.model.{HttpEntity, HttpResponse}
 import org.reactivestreams.{Publisher, Subscriber, Subscription}
 import org.scalatest.OptionValues
 import org.scalatest.matchers.should.Matchers


### PR DESCRIPTION
To make it consistent with the style of Scala in pekko. In my view I would also classify this as a formatting commit, if you agree then do a rebase and merge so I can add it to `.git-blame-ignore-revs`.

@pjfanning 