### PR TITLE
When a content-length 0 gzipped file head request made, do not error out

### DIFF
--- a/src/main/scala/com/github/pjfanning/pekkohttpspi/RequestRunner.scala
+++ b/src/main/scala/com/github/pjfanning/pekkohttpspi/RequestRunner.scala
@@ -40,6 +40,7 @@ class RequestRunner()(implicit sys: ActorSystem, ec: ExecutionContext, mat: Mate
       handler.onHeaders(toSdkHttpFullResponse(response))
 
       val (complete, publisher) = response.entity.dataBytes
+        .filter(_.nonEmpty)
         .map(_.asByteBuffer)
         .alsoToMat(Sink.ignore)(Keep.right)
         .toMat(Sink.asPublisher(fanout = false))(Keep.both)

--- a/src/test/scala/com/github/pjfanning/pekkohttpspi/s3/TestS3.scala
+++ b/src/test/scala/com/github/pjfanning/pekkohttpspi/s3/TestS3.scala
@@ -123,6 +123,29 @@ class TestS3 extends BaseAwsClientTest[S3AsyncClient] {
       result.asUtf8String() should be(fileContent + fileContent)
     }
 
+    "upload and head request gzip file with 0 content-length" in withClient { implicit client =>
+      val bucketName = createBucket()
+      val fileName = "my-empty-file"
+      val contentLength = 0L
+      val contentType = "application/json"
+      val contentEncoding = "gzip"
+
+      client
+        .putObject(PutObjectRequest.builder().bucket(bucketName).key(fileName).contentType(contentType).contentLength(contentLength).contentEncoding(contentEncoding).build(),
+                   AsyncRequestBody.fromString("")
+        )
+        .join
+
+      val result = client
+        .headObject(HeadObjectRequest.builder().bucket(bucketName).key(fileName).build()
+        )
+        .join
+
+      result.contentLength() should be(contentLength)
+      result.contentType() should be(contentType)
+      result.contentEncoding() should be(contentEncoding)
+    }
+
   }
 
   def createBucket()(implicit client: S3AsyncClient): String = {

--- a/src/test/scala/com/github/pjfanning/pekkohttpspi/s3/TestS3.scala
+++ b/src/test/scala/com/github/pjfanning/pekkohttpspi/s3/TestS3.scala
@@ -124,21 +124,28 @@ class TestS3 extends BaseAwsClientTest[S3AsyncClient] {
     }
 
     "upload and head request gzip file with 0 content-length" in withClient { implicit client =>
-      val bucketName = createBucket()
-      val fileName = "my-empty-file"
-      val contentLength = 0L
-      val contentType = "application/json"
+      val bucketName      = createBucket()
+      val fileName        = "my-empty-file"
+      val contentLength   = 0L
+      val contentType     = "application/json"
       val contentEncoding = "gzip"
 
       client
-        .putObject(PutObjectRequest.builder().bucket(bucketName).key(fileName).contentType(contentType).contentLength(contentLength).contentEncoding(contentEncoding).build(),
-                   AsyncRequestBody.fromString("")
+        .putObject(
+          PutObjectRequest
+            .builder()
+            .bucket(bucketName)
+            .key(fileName)
+            .contentType(contentType)
+            .contentLength(contentLength)
+            .contentEncoding(contentEncoding)
+            .build(),
+          AsyncRequestBody.fromString("")
         )
         .join
 
       val result = client
-        .headObject(HeadObjectRequest.builder().bucket(bucketName).key(fileName).build()
-        )
+        .headObject(HeadObjectRequest.builder().bucket(bucketName).key(fileName).build())
         .join
 
       result.contentLength() should be(contentLength)


### PR DESCRIPTION
Fixes #19

The AWS SDK expects SdkHttpFullResponse.content to be null/not present in the case there is no content, but this http client violates that contract.

In my [sample project](https://github.com/jbaranski/aws-s3-head-bug), you can use the built in HTTP client instead of this one, and everything works fine.